### PR TITLE
Add function to list indexes of nominated table

### DIFF
--- a/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
@@ -194,6 +194,44 @@ class CI_DB_mysqli_connection
     {
         return isset($this->connection);
     }
+    
+    /**
+     * List Indexes
+     *
+     * Get all indexes from a given database table and return them as an associative array.
+     *
+     * @access  public
+     * @param   string  $table  Table name
+     * @return  array
+     */
+    public function get_indexes($table = '')
+    {
+        $indexes = [];
+
+        // Check to make sure table exists
+        if (! ee()->db->table_exists($table)) {
+            ee()->logger->updater(__METHOD__ . " failed. Table '" . ee()->db->dbprefix . "$table' does not exist.", true);
+            return $keys;
+        }
+
+        // Get indexes
+        $query = ee()->db->query("SHOW INDEX FROM " . ee()->db->dbprefix . "$table");
+
+        if($query->num_rows() == 0) {
+            ee()->logger->updater(__METHOD__ . " failed. Unable to get indexes from '" . ee()->db->dbprefix . "$table'.", true);
+            return $keys;
+        }
+
+        foreach ($query->result_array() as $row) {
+            $index = [];
+            foreach ($row as $column => $value) {
+                $index[strtolower($column)] = $value;
+            }
+            $indexes[] = $index;
+        }
+
+        return $indexes;
+    }
 
     /**
      * Set emulate prepares to false for SELECT statements so as not to clash


### PR DESCRIPTION
Tools exist within EE db drivers to add and remove indexes from tables, but only work if you know the name of the index(es) you want to work on.

This function makes it possible to get an array of the names of the index(es) already defined for a table, making manipulation of index(es) easier.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
